### PR TITLE
Rewrite MC6821 output channel test

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from `/apple1-wasm`
 
 ## learnings
 
-I migrated the code base from my previous [Go 6502 implementation](https://github.com/KaiWalter/go6502). Here is what I stumbled over in the beginning of the tranistion:
+I migrated the code base from my previous [Go 6502 implementation](https://github.com/KaiWalter/go6502). Here is what I stumbled over in the beginning of the transition:
 
 ### unsigned integer overflows
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ pub struct AddressBus<'a> {
     component_addr: HashMap<u16, &'a mut (dyn Addressing)>, // 1:1 map component to its addressing
 }
 ...
-pub fn read(&self, addr: u16) -> Result<u8, AddressingError> {
+pub fn read(&mut self, addr: u16) -> Result<u8, AddressingError> {
     let block = (addr as usize / self.block_size) as u16;
     if self.block_component_map.contains_key(&block) {
         let component_key = self.block_component_map[&block];
@@ -193,7 +193,7 @@ pub struct AddressBus<'a> {
     component_addr: Vec<&'a mut dyn Addressing>, // 1:1 map component to its addressing
 }
 ...
-    pub fn read(&self, addr: u16) -> Result<u8, AddressingError> {
+    pub fn read(&mut self, addr: u16) -> Result<u8, AddressingError> {
         let block = addr as usize / self.block_size;
         if self.block_component_map[block] == usize::MAX {
             Err(AddressingError::new("read", addr))


### PR DESCRIPTION
## Summary
- simplify `test_output_channel`
- remove static `ACTUAL` and capture thread
- check value by waiting on `recv_timeout`

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7b00e4748326a3f371c32a2c7d09